### PR TITLE
Fix to_python bug for integer choice fields [PD-2174]

### DIFF
--- a/django_remote_forms/fields.py
+++ b/django_remote_forms/fields.py
@@ -195,7 +195,7 @@ class RemoteTypedChoiceField(RemoteChoiceField):
         field_dict = super(RemoteTypedChoiceField, self).as_dict()
 
         field_dict.update({
-            'coerce': self.field.coerce,
+            'coerce': self.field.coerce.__name__,
             'empty_value': self.field.empty_value
         })
 

--- a/django_remote_forms/fields.py
+++ b/django_remote_forms/fields.py
@@ -217,7 +217,7 @@ class RemoteTypedMultipleChoiceField(RemoteMultipleChoiceField):
         field_dict = super(RemoteTypedMultipleChoiceField, self).as_dict()
 
         field_dict.update({
-            'coerce': self.field.coerce,
+            'coerce': self.field.coerce.__name__,
             'empty_value': self.field.empty_value
         })
 


### PR DESCRIPTION
This looks like a bug in the original code. Choicefield forms have a special 'coerce' value that gets set to the to_python method. This isn't handled correctly in resolve_promise. Replacing it with the string 'to_python' fixes the issue.

https://github.com/WiserTogether/django-remote-forms/issues/18
